### PR TITLE
Horizontally align footer ul to the middle of the page

### DIFF
--- a/client/src/App/App.css
+++ b/client/src/App/App.css
@@ -158,6 +158,7 @@ footer {
 footer > ul {
   list-style-type: none;
   color: #fff;
+  padding: 0;
 }
 
 footer > ul > li > a,


### PR DESCRIPTION
Before this fix the footer ul was offset to the right; by removing the intrinsic padding from the ul element it makes the ul align horizontally with the main element.